### PR TITLE
Fix build errors for GHC 8.4.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+dist*
+.ghc*
+cabal.project.local

--- a/Data/XML/DTD/Render.hs
+++ b/Data/XML/DTD/Render.hs
@@ -60,7 +60,7 @@ module Data.XML.DTD.Render
   , quote
   , pbracket
   , parens
-  ) 
+  )
   where
 
 import Data.XML.DTD.Types
@@ -70,9 +70,6 @@ import Data.Text.Lazy.Builder (Builder, fromText, singleton)
 import Data.Monoid (Monoid(..))
 import Data.List (intersperse)
 import System.IO (nativeNewline, Newline(CRLF))
-
--- Inline Builder combinator
-(<>) = mappend
 
 -- | Build an optional item.
 buildMaybe :: (a -> Builder) -> Maybe a -> Builder

--- a/dtd-text.cabal
+++ b/dtd-text.cabal
@@ -1,5 +1,5 @@
 name: dtd-text
-version: 0.1.2.0
+version: 0.2.0.0
 synopsis: Parse and render XML DTDs
 description:
   This library provides means to parse XML Document Type Declaration (DTD) documents.
@@ -17,12 +17,12 @@ homepage: http://github.com/m15k/hs-dtd-text
 
 library
   build-depends:
-      base >=3 && < 5
+      base
     , containers
-    , text >= 0.8
-    , dtd-types >= 0.3.0.1 && < 1
-    , xml-types ==0.3.*
-    , attoparsec >=0.10.0
+    , text
+    , dtd-types >= 0.4.0.0
+    , xml-types
+    , attoparsec
 
   exposed-modules:
     Data.XML.DTD.Parse


### PR DESCRIPTION
Hi, I fixed some build errors to get this library building on new GHC versions.

To build the dependency *dtd-types*, however, some build errors also need to be fixed.

I created a *dtd-types* Github repo with the fixed build errors at

https://github.com/jamesdbrock/dtd-types

and sent an email to you and Yitzchak Gale. What do you think?